### PR TITLE
アカウントメニューとプロフィール・設定ページの追加

### DIFF
--- a/app/components/AccountMenu.tsx
+++ b/app/components/AccountMenu.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import Link from 'next/link';
+
+export default function AccountMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-10 h-10 rounded-full bg-pink-100 flex items-center justify-center hover:bg-pink-200"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#666">
+          <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-10">
+          <Link href="/profile" className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+            プロフィール
+          </Link>
+          <Link href="/settings" className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+            設定
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,29 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import AccountMenu from './components/AccountMenu';
 
 export default function Page() {
     return (
-        <main className="flex justify-center items-center h-screen">
-            <div className="text-center">
-                <Image
-                    src="/ai_character.png"
-                    width={200}
-                    height={200}
-                    alt="AI character"
-                />
-                <Link
-                    href="/conversation"
-                    className="mt-[25vh] block rounded-lg bg-pink-100 px-5 py-5 font-serif hover:bg-pink-200"
-                >
-                    <p>今日の振り返りを始めるよ</p>
-                </Link>
+        <main className="relative min-h-screen">
+            <div className="absolute top-4 right-4">
+                <AccountMenu />
             </div>
-        </main >
+            <div className="flex justify-center items-center h-screen">
+                <div className="text-center">
+                    <Image
+                        src="/ai_character.png"
+                        width={200}
+                        height={200}
+                        alt="AI character"
+                    />
+                    <Link
+                        href="/conversation"
+                        className="mt-[25vh] block rounded-lg bg-pink-100 px-5 py-5 font-serif hover:bg-pink-200"
+                    >
+                        <p>今日の振り返りを始めるよ</p>
+                    </Link>
+                </div>
+            </div>
+        </main>
     );
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+export default function ProfilePage() {
+  return (
+    <main className="min-h-screen p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-2xl font-bold mb-6">プロフィール</h1>
+        
+        <div className="bg-white p-6 rounded-lg shadow-md">
+          <div className="mb-6">
+            <h2 className="text-lg font-semibold mb-2">ユーザー情報</h2>
+            <p className="mb-1">名前: ユーザー</p>
+            <p className="mb-1">メール: user@example.com</p>
+            <p>登録日: 2023年4月1日</p>
+          </div>
+          
+          <div className="mb-6">
+            <h2 className="text-lg font-semibold mb-2">活動統計</h2>
+            <p className="mb-1">振り返り回数: 42回</p>
+            <p>最近の振り返り: 2023年10月15日</p>
+          </div>
+          
+          <div className="flex justify-between">
+            <Link href="/" className="text-pink-500 hover:underline">
+              ホームに戻る
+            </Link>
+            <Link href="/settings" className="bg-pink-100 px-4 py-2 rounded hover:bg-pink-200">
+              設定ページへ
+            </Link>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+} 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+export default function SettingsPage() {
+  const [notifications, setNotifications] = useState(true);
+  const [theme, setTheme] = useState('light');
+  const [language, setLanguage] = useState('ja');
+
+  return (
+    <main className="min-h-screen p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-2xl font-bold mb-6">設定</h1>
+        
+        <div className="bg-white p-6 rounded-lg shadow-md mb-6">
+          <h2 className="text-lg font-semibold mb-4">アプリ設定</h2>
+          
+          <div className="mb-4">
+            <label className="flex items-center cursor-pointer">
+              <input 
+                type="checkbox" 
+                checked={notifications}
+                onChange={() => setNotifications(!notifications)}
+                className="w-4 h-4 mr-2"
+              />
+              <span>通知を受け取る</span>
+            </label>
+          </div>
+          
+          <div className="mb-4">
+            <label className="block mb-2">テーマ</label>
+            <select 
+              value={theme}
+              onChange={(e) => setTheme(e.target.value)}
+              className="w-full p-2 border rounded"
+            >
+              <option value="light">ライト</option>
+              <option value="dark">ダーク</option>
+              <option value="system">システム設定に合わせる</option>
+            </select>
+          </div>
+          
+          <div className="mb-4">
+            <label className="block mb-2">言語</label>
+            <select 
+              value={language}
+              onChange={(e) => setLanguage(e.target.value)}
+              className="w-full p-2 border rounded"
+            >
+              <option value="ja">日本語</option>
+              <option value="en">English</option>
+            </select>
+          </div>
+        </div>
+        
+        <div className="flex justify-between">
+          <Link href="/" className="text-pink-500 hover:underline">
+            ホームに戻る
+          </Link>
+          <Link href="/profile" className="bg-pink-100 px-4 py-2 rounded hover:bg-pink-200">
+            プロフィールページへ
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+} 


### PR DESCRIPTION
# アカウントメニューとユーザーページの追加

## 変更内容
- ホーム画面の右上にアカウントボタンを追加
- アカウントボタンにドロップダウンメニューを実装
  - プロフィールページへのリンク
  - 設定ページへのリンク
- 新規ページを作成
  - プロフィールページ (/profile)
  - 設定ページ (/settings)

## 実装詳細
- アカウントボタンはSVGアイコンを使用（ユーザーアイコン）
- ドロップダウンは外部クリックで閉じる機能あり
- プロフィールページはユーザー情報と統計情報を表示
- 設定ページでは通知設定、テーマ、言語設定が可能

## 画面イメージ
- ホーム画面に右上にアカウントアイコンを配置
- クリックするとプロフィールと設定へのリンクが表示
- 各リンクから対応するページへ移動可能

## テスト方法
1. ホーム画面でアカウントアイコンが表示されることを確認
2. アイコンをクリックしてドロップダウンが表示されることを確認
3. ドロップダウン内のリンクからプロフィールと設定ページに移動できることを確認
4. 外部クリックでドロップダウンが閉じることを確認