### PR TITLE
開発環境のルール追加

### DIFF
--- a/.cursor/rules/frontend-coding-rule.mdc
+++ b/.cursor/rules/frontend-coding-rule.mdc
@@ -1,0 +1,10 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+
+# Your rule content
+
+- You can @ files here
+- You can use markdown but dont have to

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,0 @@
-# Gemini API キー (https://aistudio.google.com/app/apikey から取得)
-GEMINI_API_KEY=your_gemini_api_key_here
-
-# ElevenLabs API キー (https://elevenlabs.io/app/account から取得)
-ELEVEN_LABS_API_KEY=your_eleven_labs_api_key_here
-
-# 本番環境では "production" に設定
-NODE_ENV=development 

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 /lib/placeholder-data.ts
+
+# rules
+/rules/
+

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ npm install
 # docs/[ドキュメント名] - ドキュメント更新
 # refactor/[リファクタリング内容] - コードリファクタリング
 # voice/[機能名] - 音声関連機能
+# hotfix/[修正内容] - 細かい修正
+
 
 git checkout -b [ブランチ名]
 ```


### PR DESCRIPTION
# 開発環境のルールファイルをGit管理から除外

## 変更内容
- `.gitignore`に`/rules/`ディレクトリを追加し、開発環境のルールファイルをGit管理から除外
- これにより、ローカル開発環境固有のルールファイルがリポジトリに含まれないようになる

## 理由
- 開発環境固有のルールファイルは、チームメンバーごとに異なる可能性があるため、Git管理から除外する必要あり

## 影響範囲
- ローカル開発環境のルールファイルのみに影響
- 本番環境や他の開発環境には影響なし